### PR TITLE
Replace ReactSimpleDropdown with original component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "js-cookie": "^2.1.4",
     "keymirror": "^0.1.1",
     "lodash": "^4.17.4",
     "material-ui": "^0.18.0",
+    "radium": "^0.18.2",
     "react": "15.4.0",
     "react-dom": "^15.5.4",
     "react-markdown": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "react-native": "0.43.4",
     "react-redux": "^5.0.4",
     "react-router-dom": "^4.1.1",
-    "react-simple-dropdown": "^3.0.0",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
     "redux-logger": "^3.0.1",

--- a/public/index.css
+++ b/public/index.css
@@ -2,41 +2,7 @@ body {
   margin: 0;
 }
 
-/* react-simple-dropdown */
-.dropdown {
-  display: inline-block;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  color: #2b546a;
+a {
+  color: inherit;
+  text-decoration: none;
 }
-
-.dropdown:hover {
-  color: #1c3746;
-  background: #f0f4f9;
-}
-
-.dropdown__content {
-  display: none;
-  position: absolute;
-  background: white;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.16);
-  border-radius: 2px;
-  color: #2b546a;
-  font-size: 13px;
-}
-
-.dropdown__content > div {
-  cursor: pointer;
-  padding: 14px 20px;
-  transition: all 0.3s ease;
-}
-.dropdown__content > div:hover {
-  color: #1c3746;
-  background: #f0f4f9;
-}
-
-.dropdown--active .dropdown__content {
-  display: block;
-}
-
-/* END: react-simple-dropdown */

--- a/src/web/components/dropdown/dropdown_content.js
+++ b/src/web/components/dropdown/dropdown_content.js
@@ -2,6 +2,25 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Radium from 'radium'
 
+@Radium
+class DropdownContent extends PureComponent {
+  render () {
+    const {children, isActive} = this.props
+
+    if (!isActive) {
+      return <div />
+    }
+
+    return (
+      <div style={[styles.root]}>
+        {React.Children.map(children, (child) => (
+          React.cloneElement(child, {style: [styles.item]})
+        ))}
+      </div>
+    )
+  }
+}
+
 const styles = {
   root: {
     position: 'absolute',
@@ -22,25 +41,6 @@ const styles = {
       background: '#f0f4f9',
     },
   },
-}
-
-@Radium
-class DropdownContent extends PureComponent {
-  render () {
-    const {children, isActive} = this.props
-
-    if (!isActive) {
-      return <div />
-    }
-
-    return (
-      <div style={[styles.root]}>
-        {React.Children.map(children, (child) => (
-          React.cloneElement(child, {style: [styles.item]})
-        ))}
-      </div>
-    )
-  }
 }
 
 DropdownContent.displayName = 'DropdownContent'

--- a/src/web/components/dropdown/dropdown_content.js
+++ b/src/web/components/dropdown/dropdown_content.js
@@ -1,0 +1,53 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import Radium from 'radium'
+
+const styles = {
+  root: {
+    position: 'absolute',
+    background: 'white',
+    boxShadow: '0 3px 10px rgba(0,0,0,0.16)',
+    borderRadius: 2,
+    color: '#2b546a',
+    fontSize: 13,
+  },
+  item: {
+    display: 'block',
+    cursor: 'pointer',
+    padding: '14px 20px',
+    transition: 'all 0.3s ease',
+
+    ':hover': {
+      color: '#1c3746',
+      background: '#f0f4f9',
+    },
+  },
+}
+
+@Radium
+class DropdownContent extends PureComponent {
+  render () {
+    const {children, isActive} = this.props
+
+    if (!isActive) {
+      return <div />
+    }
+
+    return (
+      <div style={[styles.root]}>
+        {React.Children.map(children, (child) => (
+          React.cloneElement(child, {style: [styles.item]})
+        ))}
+      </div>
+    )
+  }
+}
+
+DropdownContent.displayName = 'DropdownContent'
+
+DropdownContent.propTypes = {
+  children: PropTypes.node,
+  isActive: PropTypes.bool,
+}
+
+export default DropdownContent

--- a/src/web/components/dropdown/dropdown_trigger.js
+++ b/src/web/components/dropdown/dropdown_trigger.js
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react';
+import {findDOMNode} from 'react-dom'
+import PropTypes from 'prop-types';
+import Radium from 'radium'
+
+@Radium
+class DropdownTrigger extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {isActive: false}
+    this._onWindowClick = this.onWindowClick.bind(this)
+  }
+
+  componentDidMount () {
+    window.addEventListener('click', this._onWindowClick)
+    window.addEventListener('touchstart', this._onWindowClick)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('click', this._onWindowClick)
+    window.removeEventListener('touchstart', this._onWindowClick)
+  }
+
+  onWindowClick (event) {
+    const dropdownElement = findDOMNode(this)
+    if (event.target !== dropdownElement && !dropdownElement.contains(event.target)) {
+      this.props.hide()
+    }
+  }
+
+  render () {
+    const { children, onClick } = this.props
+    return (
+      <a onClick={onClick}>
+        {children}
+      </a>
+    )
+  }
+}
+
+DropdownTrigger.displayName = 'DropdownTrigger';
+
+DropdownTrigger.propTypes = {
+  children: PropTypes.node,
+}
+
+export default DropdownTrigger

--- a/src/web/components/dropdown/index.js
+++ b/src/web/components/dropdown/index.js
@@ -1,0 +1,99 @@
+import React, {cloneElement, PureComponent} from 'react'
+import PropTypes from 'prop-types'
+import {findDOMNode} from 'react-dom'
+import Radium from 'radium'
+
+import DropdownTrigger from './dropdown_trigger'
+import DropdownContent from './dropdown_content'
+
+@Radium
+class Dropdown extends PureComponent {
+  displayName: 'Dropdown'
+
+  constructor (props) {
+    super(props)
+    this.state = {isActive: false}
+  }
+
+  hide () {
+    this.setState({isActive: false}, () => {
+      if (this.props.onHide) {
+        this.props.onHide()
+      }
+    })
+  }
+
+  show () {
+    this.setState({isActive: true}, () => {
+      if (this.props.onShow) {
+        this.props.onShow()
+      }
+    })
+  }
+
+  onToggleClick (event) {
+    event.preventDefault()
+    if (this.state.isActive) {
+      this.hide()
+    } else {
+      this.show()
+    }
+  }
+
+  render () {
+    const {children} = this.props
+    const {isActive} = this.state
+    // stick callback on trigger element
+    const boundChildren = React.Children.map(children, (child) => {
+      if (child.type === DropdownTrigger) {
+        const originalOnClick = child.props.onClick
+        child = cloneElement(child, {
+          ref: 'trigger',
+          hide: this.hide.bind(this),
+          onClick: (event) => {
+            this.onToggleClick(event)
+            if (originalOnClick) {
+              originalOnClick.apply(child, arguments)
+            }
+          }
+        })
+      }
+
+      if (child.type === DropdownContent) {
+        child = cloneElement(child, {isActive})
+      }
+
+      return child
+    })
+
+    return (
+      <div style={[styles.dropdown, this.props.style]} >
+        {boundChildren}
+      </div>
+    )
+  }
+}
+
+const styles = {
+  dropdown: {
+    display: 'inline-block',
+    cursor: 'pointer',
+    transition: 'all 0.3s ease',
+    color: '#2b546a',
+
+    ':hover': {
+      color: '#1c3746',
+      background: '#f0f4f9',
+    },
+  },
+}
+
+Dropdown.propTypes = {
+  onHide: PropTypes.func,
+  onShow: PropTypes.func,
+  children: PropTypes.node,
+  style: PropTypes.object
+}
+
+export {DropdownTrigger, DropdownContent}
+export default Dropdown

--- a/src/web/containers/header/after_login_header_container.js
+++ b/src/web/containers/header/after_login_header_container.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {withRouter} from 'react-router-dom'
-import Dropdown, {DropdownTrigger, DropdownContent} from 'react-simple-dropdown'
+import {withRouter, Link} from 'react-router-dom'
 import Avatar from 'material-ui/Avatar'
+import Dropdown, {DropdownTrigger, DropdownContent} from '../../components/dropdown'
 import PostFormModal from '../../components/post_form_modal'
 import {createPost} from '../../../actions/post'
 import {
@@ -100,6 +100,7 @@ class AfterLoginHeader extends React.PureComponent {
                 <span style={styles.userName}>{me.name}</span>
               </DropdownTrigger>
               <DropdownContent style={styles.dropdownContent}>
+                <div><Link to='/mypage'>マイページ</Link></div>
                 <div onClick={() => { this.props.signOut() }}>ログアウト</div>
               </DropdownContent>
             </Dropdown>

--- a/src/web/containers/router/index.js
+++ b/src/web/containers/router/index.js
@@ -1,5 +1,7 @@
-import _OnlyBeforeSignedInRoute from './only_before_signin_router'
-import _PrivateRoute from './private_router'
+import OnlyBeforeSignedInRoute from './only_before_signin_router'
+import PrivateRoute from './private_router'
 
-export const OnlyBeforeSignedInRoute = _OnlyBeforeSignedInRoute
-export const PrivateRoute = _PrivateRoute
+export {
+  OnlyBeforeSignedInRoute,
+  PrivateRoute,
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
+          plugins: ["transform-decorators-legacy"],
           presets: ["react", "es2015", "stage-0"]
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,6 +155,10 @@ array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+
 array-map@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
@@ -502,7 +506,7 @@ babel-plugin-syntax-class-properties@^6.5.0, babel-plugin-syntax-class-propertie
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
-babel-plugin-syntax-decorators@^6.13.0:
+babel-plugin-syntax-decorators@^6.1.18, babel-plugin-syntax-decorators@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
 
@@ -582,6 +586,14 @@ babel-plugin-transform-class-properties@^6.24.1, babel-plugin-transform-class-pr
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-plugin-transform-decorators-legacy@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz#741b58f6c5bce9e6027e0882d9c994f04f366925"
+  dependencies:
+    babel-plugin-syntax-decorators "^6.1.18"
+    babel-runtime "^6.2.0"
+    babel-template "^6.3.0"
 
 babel-plugin-transform-decorators@^6.24.1:
   version "6.24.1"
@@ -1080,14 +1092,14 @@ babel-register@^6.18.0, babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.3.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -1201,7 +1213,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.6.0:
+bowser@^1.0.0, bowser@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.1.tgz#9157e9498f456e937173a2918f3b2161e5353eb3"
 
@@ -1410,10 +1422,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
-
-classnames@^2.1.2:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -2249,6 +2257,10 @@ exenv@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.0.tgz#3835f127abf075bfe082d0aed4484057c78e3c89"
 
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2763,7 +2775,7 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-hyphenate-style-name@^1.0.2:
+hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
@@ -2825,6 +2837,13 @@ inherits@2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inline-style-prefixer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
+  dependencies:
+    bowser "^1.0.0"
+    hyphenate-style-name "^1.0.1"
 
 inline-style-prefixer@^3.0.2:
   version "3.0.3"
@@ -4256,7 +4275,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.1, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.0.0, prop-types@^15.5.1, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -4303,6 +4322,15 @@ querystring-es3@^0.2.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+radium@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/radium/-/radium-0.18.2.tgz#1e296966d0bcac6652085cbe84c7b8ed0196d7c1"
+  dependencies:
+    array-find "^1.0.0"
+    exenv "^1.2.1"
+    inline-style-prefixer "^2.0.5"
+    rimraf "^2.6.1"
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -4530,13 +4558,6 @@ react-router@^4.1.1:
     path-to-regexp "^1.5.3"
     prop-types "^15.5.4"
     warning "^3.0.0"
-
-react-simple-dropdown@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-simple-dropdown/-/react-simple-dropdown-3.0.0.tgz#5a2cac441748a090a3b7009b4807ea206002b7c3"
-  dependencies:
-    classnames "^2.1.2"
-    prop-types "^15.5.8"
 
 react-tap-event-plugin@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
<img width="241" alt="2017-05-05 11 19 34" src="https://cloud.githubusercontent.com/assets/6408742/25731901/3437e348-3185-11e7-9eb6-647823f9cebd.png">

ReactSimpleDropdownというライブラリを自前で置き換えた。
以下理由
・そもそもCSSは自分で追加しなきゃいけないというイマイチなライブラリ設計
・マイページのリンクをクリックしてもドロップダウン消えない仕様だった（これがメインの理由）

大部分は以下から取ってきています。
https://github.com/Fauntleroy/react-simple-dropdown/blob/master/src/components/Dropdown.jsx